### PR TITLE
Add AWSTemplateFormatVersion boilerplate

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1,3 +1,4 @@
+AWSTemplateFormatVersion: 2010-09-09
 Resources:
   PipelineArtifactsBucketEncryptionKeyF5BF0670:
     Type: AWS::KMS::Key


### PR DESCRIPTION
While technically optional, the AWSTemplateFormatVersion key is used by various tools to recognize this document as an AWS CloudFormation template.

Per [our twitter conversation](https://twitter.com/naumenko_roman/status/1364704443095273472?s=21), we believe the lack of this key is why our registry prototype rejected the template. We'll improve the system to handle this situation better but I thought I'd offer the fix in case that's helpful. 

Thanks again for reaching out! 